### PR TITLE
Explicitly pass all parameters to getPrettyRepresentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Jetbrains
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Jetbrains
 .idea/
+
+# NPM
+node_modules/

--- a/formatter.js
+++ b/formatter.js
@@ -110,7 +110,7 @@ function prettifyJson(object, indent, lineLength) {
                 const ans = ["[\n"];
                 for (const e of currentNode) {
                     ans.push(" ".repeat(nextIndent + indent));
-                    ans.push(getPrettyRepresentation(e, nextIndent + indent, nextIndent + indent));
+                    ans.push(getPrettyRepresentation(e, nextIndent + indent, nextIndent + indent, false));
                     ans.push(ARRAY_SEP);
                     ans.push("\n");
                 }
@@ -146,7 +146,7 @@ function prettifyJson(object, indent, lineLength) {
                     ans.push(
                         getPrettyRepresentation(v,
                             nextIndent + indent + JSON.stringify(k).length + OBJ_KV_SEP.length,
-                            nextIndent + indent));
+                            nextIndent + indent, false));
                     ans.push(ARRAY_SEP);
                     ans.push("\n");
                 }
@@ -164,7 +164,7 @@ function prettifyJson(object, indent, lineLength) {
         }
     }
 
-    const result = getPrettyRepresentation(object, 0, 0);
+    const result = getPrettyRepresentation(object, 0, 0, false);
     const trimmedResult = result.split("\n").map(s => s.trimEnd()).join("\n");
     return trimmedResult;
 }

--- a/formatter.js
+++ b/formatter.js
@@ -146,7 +146,8 @@ function prettifyJson(object, indent, lineLength) {
                     ans.push(
                         getPrettyRepresentation(v,
                             nextIndent + indent + JSON.stringify(k).length + OBJ_KV_SEP.length,
-                            nextIndent + indent, false));
+                            nextIndent + indent,
+                            false));
                     ans.push(ARRAY_SEP);
                     ans.push("\n");
                 }


### PR DESCRIPTION
# Overview
Currently there are several callsites where `getPrettyRepresentation` is invoked with 3 arguments instead of 4. According to my research, this will mean that the 4th parameter (`forceSingleLine`) will resolve to undefined, which will be truthy false, which should *just work*.

But better to be explicit.

# The chance
&check; Explicitly pass all arguments to `getPrettyRepresentation` on all call paths
&check; Add .gitignore
&check; Update .gitignore with stuff relevant to NPM/WebStorm